### PR TITLE
VaultRegistry address updated for Arbitrum and Berachain

### DIFF
--- a/sdk-js/src/addresses/addresses.json
+++ b/sdk-js/src/addresses/addresses.json
@@ -11,7 +11,7 @@
     "42161": {
       "contracts": {
         "VaultRegistry": {
-          "current": "0x3f187baC1e70174ffBc8678CC4d321994c60c36d"
+          "current": "0xa3c82022f2a86e4e85c2e298c14fe7f216c537d2"
         }
       },
       "name": "Arbitrum One"
@@ -19,7 +19,7 @@
     "80094": {
       "contracts": {
         "VaultRegistry": {
-          "current": "0x94c8e3ac7D95c7cA1151bFD3fadfaD3E8b06967b"
+          "current": "0x7f3b63828f228afc2c5822796799c27ed843f418"
         }
       },
       "name": "Berachain"


### PR DESCRIPTION
A new deployment has been made for the latest version of the contracts