### PR TITLE
fix: token symbol for total balance corrected

### DIFF
--- a/frontend/src/components/pages/borrow/BorrowModal.tsx
+++ b/frontend/src/components/pages/borrow/BorrowModal.tsx
@@ -527,7 +527,7 @@ export function BorrowModal({
                         predictedTokensToReceive,
                         selectedStrategy.token.decimals
                       ).text
-                    } ${collateralAsset.symbol}`
+                    } ${selectedStrategy.token.symbol}`
                   : "N/A"
               }
             />


### PR DESCRIPTION
<img width="734" height="155" alt="image" src="https://github.com/user-attachments/assets/a176a9c8-381d-4eb6-b109-9f60f58e2433" />

Total balance value is correct, but its token should be PT, not USDC. This PR fixes the issue.