### PR TITLE
ci: check for chengesets in a separate job

### DIFF
--- a/.github/actions/lint/action.yaml
+++ b/.github/actions/lint/action.yaml
@@ -1,12 +1,6 @@
 name: "Lint"
 description: "Lints the code in the repo"
 
-inputs:
-  check-changesets:
-    description: "Whether to check for pending changesets"
-    default: false
-    required: false
-
 runs:
   using: "composite"
   steps:
@@ -37,26 +31,4 @@ runs:
 
     - name: Check that workspace packages use current versions
       run: npm run check:packages-sync
-      shell: bash
-
-    - name: Fetch base branch
-      if: ${{ inputs.check-changesets == 'true' }}
-      shell: bash
-      run: git fetch origin ${{ github.base_ref }} --depth=1
-
-    - name: Check for pending Changesets
-      id: changesets
-      if: ${{ inputs.check-changesets == 'true' }}
-      run: npm run check:changesets -- --since=origin/${{ github.base_ref }}
-      shell: bash
-      continue-on-error: true
-
-    - name: Changesets warning
-      if: ${{ steps.changesets.outcome == 'failure' }}
-      run: |
-        echo "::warning title=Changesets::Packages changed but no changesets found. Run 'npm run changeset:add' (or 'changeset add --empty' if no release needed)."
-        echo "### Changesets" >> $GITHUB_STEP_SUMMARY
-        echo "Packages changed but no changesets found." >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Run \`npm run changeset:add\` (or \`changeset add --empty\`)." >> $GITHUB_STEP_SUMMARY
       shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Lint
         uses: ./.github/actions/lint
-        with:
-          check-changesets: ${{ github.event_name == 'pull_request' }}
 
       - name: Build
         uses: ./.github/actions/build

--- a/.github/workflows/check-changesets.yaml
+++ b/.github/workflows/check-changesets.yaml
@@ -1,0 +1,76 @@
+name: Check changesets
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-changesets:
+    name: Check Changesets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          setup-node: true
+          audit: false
+
+      - name: Fetch base branch
+        shell: bash
+        run: git fetch origin ${{ github.base_ref }} --depth=1
+
+      - name: Check for pending Changesets
+        id: changesets
+        shell: bash
+        continue-on-error: true
+        run: |
+          set +e
+          npm run check:changesets -- --since=${{ github.event.pull_request.base.sha }}
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: HOW TO FIX MISSING CHANGESET
+        if: steps.changesets.outputs.exit_code != '0'
+        shell: bash
+        run: |
+          echo "::group::Changesets required"
+          echo "This PR changes one or more packages but does not include a Changeset."
+          echo ""
+          echo "What you need to do:"
+          echo "1) Run: npx changeset add"
+          echo "2) Pick the package(s) you changed"
+          echo "3) Choose bump type:"
+          echo "   - patch: bugfix/internal change, no API change"
+          echo "   - minor: new feature, backwards compatible"
+          echo "   - major: breaking change"
+          echo "4) Write a short, user-facing summary"
+          echo "5) Commit the generated file under .changeset/*.md"
+          echo ""
+          echo "If this PR should not trigger a release:"
+          echo "Run: npx changeset add --empty"
+          echo "Then commit the generated empty changeset."
+          echo "::endgroup::"
+          {
+            echo "## Changesets required"
+            echo ""
+            echo "This PR changes one or more packages but does not include a Changeset."
+            echo ""
+            echo "### Fix"
+            echo "Run \`npx changeset add\` and commit the generated \`.changeset/*.md\` file."
+            echo ""
+            echo "### No release needed?"
+            echo "Run \`npx changeset add --empty\` and commit it."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1


### PR DESCRIPTION
fixes #150 

this patch introduces new CI job to check if `changesets` were attached to PR. This CI job is optional and PR can be merged if there are no `changesets` attached.
IMO it is the most balanced way to remind developers to add `changesets` to PR to make releases.
